### PR TITLE
Fix NULL pointer crash in OQS KEM encaps/decaps error handling

### DIFF
--- a/kexoqs.c
+++ b/kexoqs.c
@@ -42,7 +42,7 @@ static int kex_kem_generic_keypair(OQS_KEM *kem, struct kex *kex)
 {
   struct sshbuf *buf = NULL;
   u_char *cp = NULL;
-  int r;
+  int r = SSH_ERR_INTERNAL_ERROR;
   if ((buf = sshbuf_new()) == NULL) {
     return SSH_ERR_ALLOC_FAIL;
   }
@@ -71,7 +71,7 @@ static int kex_kem_generic_enc(OQS_KEM *kem, struct kex *kex,
   struct sshbuf *buf = NULL;
   const u_char *client_pub;
   u_char *kem_key = NULL, *ciphertext;
-  int r;
+  int r = SSH_ERR_INTERNAL_ERROR;
   *server_blobp = NULL;
   *shared_secretp = NULL;
   if (sshbuf_len(client_blob) != kem->length_public_key) {
@@ -125,7 +125,7 @@ static int kex_kem_generic_dec(OQS_KEM *kem,
   struct sshbuf *buf = NULL;
   u_char *kem_key = NULL;
   const u_char *ciphertext;
-  int r;
+  int r = SSH_ERR_INTERNAL_ERROR;
   *shared_secretp = NULL;
   if (sshbuf_len(server_blob) != kem->length_ciphertext) {
     r = SSH_ERR_SIGNATURE_INVALID;

--- a/kexoqsecdh.c
+++ b/kexoqsecdh.c
@@ -220,6 +220,7 @@ static int kex_kem_generic_with_ec_enc(OQS_KEM *kem,
 
   /* generate and encrypt KEM key with client key */
   if (OQS_KEM_encaps(kem, ciphertext, kem_key, client_pub) != OQS_SUCCESS) {
+    r = SSH_ERR_LIBCRYPTO_ERROR;
     goto out;
   }
 
@@ -319,6 +320,7 @@ static int kex_kem_generic_with_ec_dec(OQS_KEM *kem,
       goto out;
     /* decapsulate the post-quantum secret */
     if (OQS_KEM_decaps(kem, kem_key, ciphertext, kex->oqs_client_key) != OQS_SUCCESS) {
+      r = SSH_ERR_LIBCRYPTO_ERROR;
       goto out;
     }
 

--- a/kexoqsecdh.c
+++ b/kexoqsecdh.c
@@ -184,7 +184,7 @@ static int kex_kem_generic_with_ec_enc(OQS_KEM *kem,
   struct sshbuf *ecdh_server_blob = NULL;
   struct sshbuf *ecdh_shared_secret;
   u_char hash[SSH_DIGEST_MAX_LENGTH];
-  int r;
+  int r = SSH_ERR_INTERNAL_ERROR;
   *server_blobp = NULL;
   *shared_secretp = NULL;
 
@@ -295,7 +295,7 @@ static int kex_kem_generic_with_ec_dec(OQS_KEM *kem,
   struct sshbuf *ecdh_shared_secret;
   struct sshbuf *ecdh_server_blob = NULL;
   u_char hash[SSH_DIGEST_MAX_LENGTH];
-  int r;
+  int r = SSH_ERR_INTERNAL_ERROR;
   *shared_secretp = NULL;
 
   /* server_blob contains both KEM and ECDH server keys */

--- a/kexoqsx25519.c
+++ b/kexoqsx25519.c
@@ -116,6 +116,7 @@ static int kex_kem_generic_with_x25519_enc(OQS_KEM *kem, struct kex *kex,
   /* generate and encrypt KEM key with client key */
   if (OQS_KEM_encaps(kem, public_key, private_key, client_pub)
       != OQS_SUCCESS) {
+    r = SSH_ERR_LIBCRYPTO_ERROR;
     goto out;
   }
   client_pub += kem->length_public_key;
@@ -183,6 +184,7 @@ static int kex_kem_generic_with_x25519_dec(OQS_KEM *kem, struct kex *kex,
   /* decapsulate the post-quantum secret */
   if (OQS_KEM_decaps(kem, private_key, public_key,
                      kex->oqs_client_key) != OQS_SUCCESS) {
+    r = SSH_ERR_LIBCRYPTO_ERROR;
     goto out;
   }
   public_key += kem->length_ciphertext;

--- a/kexoqsx25519.c
+++ b/kexoqsx25519.c
@@ -82,7 +82,7 @@ static int kex_kem_generic_with_x25519_enc(OQS_KEM *kem, struct kex *kex,
   u_char server_key[CURVE25519_SIZE];
   u_char hash[SSH_DIGEST_MAX_LENGTH];
   size_t needed = 0;
-  int r;
+  int r = SSH_ERR_INTERNAL_ERROR;
 
   *server_blobp = NULL;
   *shared_secretp = NULL;
@@ -163,7 +163,7 @@ static int kex_kem_generic_with_x25519_dec(OQS_KEM *kem, struct kex *kex,
   size_t needed = 0;
   /* x25519 values */
   u_char hash[SSH_DIGEST_MAX_LENGTH];
-  int r;
+  int r = SSH_ERR_INTERNAL_ERROR;
 
   *shared_secretp = NULL;
 


### PR DESCRIPTION
This change looks to address a crash reported by Roumen Petrov (pkixssh@roumenpetrov.info), the developer of PKIX-SSH. The vulnerability exists in the error handling paths of `kexoqsecdh.c` and `kexoqsx25519.c` in the `OQS_KEM_encaps()` or `OQS_KEM_decaps()` functions. When OQS key encapsulation operations fail, the return value does not indicate a failure. On the error path the code uses the value `0` for variable `r` set from previous operations, causing the code to try to use either server_blobp or shared_secretp causing a NULL => bus error and crash. 

In `kexoqs.c`, error handing is handled before jumping to the cleanup code in the `OQS_KEM_encaps` and `OQS_KEM_decaps` functions by setting `r = SSH_ERR_LIBCRYPTO_ERROR;`. This PR makes a change to have the error handling logic behave the same way in `kexoqsecdh.c` and `kexoqsx25519.c`. 

I was able to reproduce this crash using the PKIX-SSH client and the OQS-SSH server when KEX algorithm list truncation caused a mismatch and failure by triggering a MAX_PROP buffer limitation in the client's `match.c` file. The confirmation was seeing `mm_reap: preauth child terminated by signal 11` in the server logs, and then verifying that line was no longer present after this change.

The reproduction steps/attack scenario this addresses are as follows:
1. A client successfully negotiates a hybrid post-quantum KEX algorithm
2. The client sends bad KEX data
3. The server's `OQS_KEM_encaps()` or `OQS_KEM_decaps()` fails to process the bad data
4. The function returns `r=0` despite the failure
5. Output pointers (`*server_blobp`, `*shared_secretp`) remain NULL
6. The caller attempts to dereference these NULL pointers
7. Server crashes

